### PR TITLE
Exclusivity

### DIFF
--- a/exclusivity
+++ b/exclusivity
@@ -1,0 +1,21 @@
+# Exclusivity
+exclusivity <- function (model, M = 30, frexw = 0.7){
+w <- frexw
+phidf <- t(as.matrix(model$phi))
+phi <- list(phidf)
+row.names(phi) <- NULL
+if (length(phi) != 1)
+stop("Exclusivity calculation only designed for models without content covariates")
+tbeta <- t(exp(phi[[1]]))
+s <- rowSums(tbeta)
+mat <- tbeta/s
+ex <- apply(mat, 2, rank)/nrow(mat)
+fr <- apply(tbeta, 2, rank)/nrow(mat)
+frex <- 1/(w/ex + (1 - w)/fr)
+index <- apply(tbeta, 2, order, decreasing = TRUE)[1:M, ]
+out <- vector(length = ncol(tbeta))
+for (i in 1:ncol(frex)) {
+out[i] <- sum(frex[index[, i], i])
+}
+print(mean(out))
+}


### PR DESCRIPTION
Calculate an exclusivity metric for a BTM model. 

This is a function adapted from the STM package to BTM, aimed to help with topic model selection (Roberts et al., 2014). 

Roberts, M., Stewart, B., Tingley, D., Lucas, C., Leder-Luis, J., Gadarian, S., Albertson, B., et al. (2014). "Structural topic models for open ended survey responses." American Journal of Political Science, 58(4), 1064-1082. http://goo.gl/0x0tHJ